### PR TITLE
Fix energies slice initialization in simulated annealing

### DIFF
--- a/anneal.go
+++ b/anneal.go
@@ -85,7 +85,7 @@ func SA(
 
 	if settings.KeepHistory {
 		res.States = make([]AnnealingState, 0, settings.MaxIterations)
-		res.Energies = make([]float64, settings.MaxIterations)
+		res.Energies = make([]float64, 0, settings.MaxIterations)
 	}
 
 	for i := 0; i < settings.MaxIterations; i++ {


### PR DESCRIPTION
Hello! I'm submitting this PR to fix the initialization of the `res.Energies` slice in `anneal.go`. It is currently initialized with a size of `settings.MaxIterations` and then inside the loop items are being appended to it. This causes the sizes of the `res.Energies` and `res.States` slices to be different.